### PR TITLE
fix: includes with data sometimes throw exceptions

### DIFF
--- a/src/Commenters/BladeCommenters/IncludeCommenter.php
+++ b/src/Commenters/BladeCommenters/IncludeCommenter.php
@@ -13,11 +13,11 @@ class IncludeCommenter implements BladeCommenter
             $excludesRegex = '(?!'.implode('|', $excludes).')';
         }
 
-        return "/@include\([\'\"]{$excludesRegex}(.*?)['\"]\)/";
+        return "/@include\((?<q>[\'\"]){$excludesRegex}(.*?)\k<q>(,(.*))?\)/s";
     }
 
     public function replacement(): string
     {
-        return '<!-- Start include: $1 -->$0<!-- End include: $1 -->';
+        return '<!-- Start include: $2 -->$0<!-- End include: $2 -->';
     }
 }

--- a/src/Commenters/BladeCommenters/IncludeIfCommenter.php
+++ b/src/Commenters/BladeCommenters/IncludeIfCommenter.php
@@ -6,18 +6,18 @@ class IncludeIfCommenter implements BladeCommenter
 {
     public function pattern(): string
     {
-        $excludeRegex = '';
+        $excludesRegex = '';
         $excludes = config('blade-comments.excludes.includes', []);
 
         if (count($excludes)) {
-            $excludeRegex = '(?!'.implode('|', $excludes).')';
+            $excludesRegex = '(?!'.implode('|', $excludes).')';
         }
 
-        return "/@includeIf\([\'\"]{$excludeRegex}(.*?)['\"]\)/";
+        return "/@includeIf\((?<q>[\'\"]){$excludesRegex}(.*?)\k<q>(,(.*))?\)/s";
     }
 
     public function replacement(): string
     {
-        return '<!-- Start includeIf: $1 -->$0<!-- End includeIf: $1 -->';
+        return '<!-- Start includeIf: $2 -->$0<!-- End includeIf: $2 -->';
     }
 }

--- a/tests/PrecompilerTests/BladeIncludeTest.php
+++ b/tests/PrecompilerTests/BladeIncludeTest.php
@@ -8,6 +8,12 @@ it('will add comments for includes', function () {
     assertMatchesHtmlSnapshot($renderedView);
 });
 
+it('will add comments for includes with data', function () {
+    $renderedView = view('includes.include.page-with-data')->render();
+
+    assertMatchesHtmlSnapshot($renderedView);
+});
+
 it('should filter excluded includes', function () {
     config(['blade-comments.excludes.includes' => ['includes.exclude']]);
 
@@ -18,6 +24,12 @@ it('should filter excluded includes', function () {
 
 it('will add comments for includeIf', function () {
     $renderedView = view('includes.includeIf.page')->render();
+
+    assertMatchesHtmlSnapshot($renderedView);
+});
+
+it('will add comments for includeIf with data', function () {
+    $renderedView = view('includes.includeIf.page-with-data')->render();
 
     assertMatchesHtmlSnapshot($renderedView);
 });

--- a/tests/TestSupport/views/includes/include/page-with-data.blade.php
+++ b/tests/TestSupport/views/includes/include/page-with-data.blade.php
@@ -1,0 +1,10 @@
+This is the start of the page
+
+@include('includes.include.include', [
+    'number' => 1,
+    'string' => 'string',
+    'array' => ['one', 'two', 'three'],
+    'function_call' => __('test'),
+])
+
+This is the end of the page

--- a/tests/TestSupport/views/includes/includeIf/page-with-data.blade.php
+++ b/tests/TestSupport/views/includes/includeIf/page-with-data.blade.php
@@ -1,0 +1,10 @@
+This is the start of the page
+
+@includeIf('includes.includeIf.includeIf', [
+    'number' => 1,
+    'string' => 'string',
+    'array' => ['one', 'two', 'three'],
+    'function_call' => __('test'),
+])
+
+This is the end of the page

--- a/tests/__snapshots__/BladeIncludeTest__it_will_add_comments_for_includeIf_with_data__1.html
+++ b/tests/__snapshots__/BladeIncludeTest__it_will_add_comments_for_includeIf_with_data__1.html
@@ -1,0 +1,7 @@
+<html><body><p>This is the start of the page
+
+<!-- Start includeIf: includes.includeIf.includeIf -->This is the includeIf
+<!-- End includeIf: includes.includeIf.includeIf -->
+
+This is the end of the page
+</p></body></html>

--- a/tests/__snapshots__/BladeIncludeTest__it_will_add_comments_for_includes_with_data__1.html
+++ b/tests/__snapshots__/BladeIncludeTest__it_will_add_comments_for_includes_with_data__1.html
@@ -1,0 +1,7 @@
+<html><body><p>This is the start of the page
+
+<!-- Start include: includes.include.include -->This is the include
+<!-- End include: includes.include.include -->
+
+This is the end of the page
+</p></body></html>


### PR DESCRIPTION
Closes #12

I think it should also be fixed in `includeWhen` & `includeUnless`, but I'm not sure why there is `\n` inside those two and if it should also be inside `include` and `includeIf`:

https://github.com/spatie/laravel-blade-comments/blob/b2a9f0382b3d71977390e22ae6434dfda81df41f/src/Commenters/BladeCommenters/IncludeUnlessCommenter.php#L16

IMHO, it might be better to also unify the logic somehow, so there won't be a need to fix 2 places each time.

WDYT?