### PR TITLE
configurable prefix for start of comments with all tests passing for #34

### DIFF
--- a/config/blade-comments.php
+++ b/config/blade-comments.php
@@ -4,6 +4,12 @@ return [
     'enable' => env('APP_DEBUG'),
 
     /*
+     * A string that is prefixed to every comment for easy searching,
+     * set to `false` or '' to disable
+     */
+    'prefix' => '',
+
+    /*
      * These classes provide regex for adding comments for
      * various Blade directives.
      */

--- a/src/BladeCommentsPrecompiler.php
+++ b/src/BladeCommentsPrecompiler.php
@@ -54,9 +54,8 @@ class BladeCommentsPrecompiler
         $prefix = '<!--';
         $string = ltrim($string);
 
-        if (substr($string, 0, strlen($prefix)) == $prefix) {
-
-            $string = '<!-- '.config('blade-comments.prefix').substr($string, strlen($prefix));
+        if (strpos($string, $prefix) === 0) {
+            $string = $prefix.' '.config('blade-comments.prefix').substr($string, strlen($prefix));
         }
 
         return $string;

--- a/src/BladeCommentsPrecompiler.php
+++ b/src/BladeCommentsPrecompiler.php
@@ -13,7 +13,7 @@ class BladeCommentsPrecompiler
             if ($commenter instanceof BladeCommenterWithCallback) {
                 $bladeContent = preg_replace_callback(
                     $commenter->pattern(),
-                    fn (array $matches) => $commenter->replacementCallback($matches),
+                    fn (array $matches) => self::insertPrefix($commenter->replacementCallback($matches)),
                     $bladeContent,
                 );
 
@@ -22,7 +22,7 @@ class BladeCommentsPrecompiler
 
             $bladeContent = preg_replace(
                 $commenter->pattern(),
-                $commenter->replacement(),
+                self::insertPrefix($commenter->replacement()),
                 $bladeContent,
             );
         }
@@ -38,5 +38,27 @@ class BladeCommentsPrecompiler
         return collect(config('blade-comments.blade_commenters'))
             ->map(fn (string $class) => app($class))
             ->toArray();
+    }
+
+    /**
+     * Insert our comment prefix
+     *
+     * @param  null|string  $string
+     */
+    public static function insertPrefix($string): ?string
+    {
+        if (! config('blade-comments.prefix')) {
+            return $string;
+        }
+
+        $prefix = '<!--';
+        $string = ltrim($string);
+
+        if (substr($string, 0, strlen($prefix)) == $prefix) {
+
+            $string = '<!-- '.config('blade-comments.prefix').substr($string, strlen($prefix));
+        }
+
+        return $string;
     }
 }

--- a/src/Http/Middleware/AddRequestComments.php
+++ b/src/Http/Middleware/AddRequestComments.php
@@ -6,6 +6,7 @@ use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response as LaravelResponse;
 use Illuminate\Support\Str;
+use Spatie\BladeComments\BladeCommentsPrecompiler;
 use Spatie\BladeComments\Commenters\RequestCommenters\RequestCommenter;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -47,7 +48,7 @@ class AddRequestComments
     {
         $comments = collect(config('blade-comments.request_commenters'))
             ->map(fn (string $class) => app($class))
-            ->map(fn (RequestCommenter $commenter) => $commenter->comment($request, $response))
+            ->map(fn (RequestCommenter $commenter) => BladeCommentsPrecompiler::insertPrefix($commenter->comment($request, $response)))
             ->filter()
             ->implode(PHP_EOL);
 

--- a/tests/PrecompilerTests/InsertPrefixTest.php
+++ b/tests/PrecompilerTests/InsertPrefixTest.php
@@ -1,0 +1,12 @@
+<?php
+
+use Spatie\BladeComments\BladeCommentsPrecompiler;
+
+it('can add a prefix to comments', function () {
+
+    config(['blade-comments.prefix' => 'BLADE_COMMENT_PREFIX']);
+
+    $output = BladeCommentsPrecompiler::insertPrefix('<!-- Start of comment -->');
+
+    $this->assertEquals($output, '<!-- BLADE_COMMENT_PREFIX Start of comment -->');
+});


### PR DESCRIPTION
Inserts a prefix so that comments by this package are easier to locate, see #34 