### PR TITLE
Fatal error if not using Livewire

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,11 @@ return [
     'blade_paths' => true,
 
     /*
-     * These classes provide regex for adding comments for
-     * various Blade directives.
+     * These classes provide regex for adding comments for various
+     * Blade directives. If not using Livewire, comment out:
+     *
+     *   - Spatie\BladeComments\Commenters\BladeCommenters\LivewireComponentCommenter::class,
+     *   - Spatie\BladeComments\Commenters\BladeCommenters\LivewireDirectiveCommenter::class,
      */
     'blade_commenters' => [
         Spatie\BladeComments\Commenters\BladeCommenters\BladeComponentCommenter::class,


### PR DESCRIPTION
At the moment the package breaks, using the default configuration file if the application does not have Livewire installed. This is due to the following lines in the configuration file:

```php
'blade_commenters' => [
      // ...
      Spatie\BladeComments\Commenters\BladeCommenters\LivewireComponentCommenter::class,
      Spatie\BladeComments\Commenters\BladeCommenters\LivewireDirectiveCommenter::class,
      // ...
  ],
```

Commenting these out obviously fixes the issue.

This is a simple PR to mention this within the readme, to avoid confusion.

This _could_ be done automatically, within `Spatie\BladeComments\Commenters\BladeCommenters\LivewireComponentCommenter::class` and `Spatie\BladeComments\Commenters\BladeCommenters\LivewireDirectiveCommenter::class` by adding the below to the first line of the `parse` method:

```php
// Livewire not installed ...
if (! class_exists(ComponentRegistry::class)) {
    return $bladeContent;
}
```

Another option is to update https://github.com/spatie/laravel-blade-comments/blob/main/src/BladeCommentsPrecompiler.php#L34-L39:

```php
protected static function commenters(): array
  {
      return collect(config('blade-comments.blade_commenters'))
        ->reject(fn (string $class) => 
            ! \class_exists(Livewire\Mechanisms\ComponentRegistry::class) &&
            \str_contains(\class_basename($class), 'Livewire')
        )
        ->map(fn (string $class) => app($class))
        ->toArray();
  }
```

However, for the moment, I've gone with the simplest option within this PR.