### PR TITLE
Support Laravel 13

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -50,6 +50,10 @@ jobs:
           echo "::add-matcher::${{ runner.tool_cache }}/php.json"
           echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
+      - name: Require Pest 4 for Laravel 13
+        if: matrix.laravel == '13.*'
+        run: composer require "pestphp/pest:^4.0" "pestphp/pest-plugin-laravel:^4.0" "pestphp/pest-plugin-arch:^4.0" --dev --no-interaction --no-update
+
       - name: Install dependencies
         run: |
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         php: [8.4, 8.3, 8.2]
-        laravel: ['10.*', '11.*', '12.*']
+        laravel: ['10.*', '11.*', '12.*', '13.*']
         stability: [prefer-stable]
         include:
           - laravel: 10.*
@@ -26,6 +26,11 @@ jobs:
             testbench: 9.*
           - laravel: 12.*
             testbench: 10.*
+          - laravel: 13.*
+            testbench: 11.*
+        exclude:
+          - laravel: 13.*
+            php: 8.2
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -26,17 +26,17 @@
     ],
     "require": {
         "php": "^8.2",
-        "illuminate/contracts": "^10|^11.0|^12.0",
-        "illuminate/view": "^10|^11.0|^12.0",
+        "illuminate/contracts": "^10|^11.0|^12.0|^13.0",
+        "illuminate/view": "^10|^11.0|^12.0|^13.0",
         "spatie/laravel-package-tools": "^1.19",
         "stillat/blade-parser": "^2.0",
         "symfony/filesystem": "^7.0|^8.0"
     },
     "require-dev": {
         "laravel/pint": "^1.21",
-        "livewire/livewire": ">=3.5.20",
+        "livewire/livewire": "^3.5.20|^4.0",
         "nunomaduro/collision": "^7|^8.6.1",
-        "orchestra/testbench": "^8.5.4|^9.11|^10.0",
+        "orchestra/testbench": "^8.5.4|^9.11|^10.0|^11.0",
         "pestphp/pest": "^2.6.1|^3.7.4",
         "pestphp/pest-plugin-arch": "^2.1.2|^3.0",
         "pestphp/pest-plugin-laravel": "^2.0|^3.1",

--- a/composer.json
+++ b/composer.json
@@ -37,9 +37,9 @@
         "livewire/livewire": "^3.5.20|^4.0",
         "nunomaduro/collision": "^7|^8.6.1",
         "orchestra/testbench": "^8.5.4|^9.11|^10.0|^11.0",
-        "pestphp/pest": "^2.6.1|^3.7.4",
-        "pestphp/pest-plugin-arch": "^2.1.2|^3.0",
-        "pestphp/pest-plugin-laravel": "^2.0|^3.1",
+        "pestphp/pest": "^2.6.1|^3.7.4|^4.0",
+        "pestphp/pest-plugin-arch": "^2.1.2|^3.0|^4.0",
+        "pestphp/pest-plugin-laravel": "^2.0|^3.1|^4.0",
         "spatie/laravel-ray": "^1.39.1",
         "spatie/pest-plugin-snapshots": "^2.2.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -37,9 +37,9 @@
         "livewire/livewire": "^3.5.20|^4.0",
         "nunomaduro/collision": "^7|^8.6.1",
         "orchestra/testbench": "^8.5.4|^9.11|^10.0|^11.0",
-        "pestphp/pest": "^2.6.1|^3.7.4|^4.0",
-        "pestphp/pest-plugin-arch": "^2.1.2|^3.0|^4.0",
-        "pestphp/pest-plugin-laravel": "^2.0|^3.1|^4.0",
+        "pestphp/pest": "^2.6.1|^3.7.4",
+        "pestphp/pest-plugin-arch": "^2.1.2|^3.0",
+        "pestphp/pest-plugin-laravel": "^2.0|^3.1",
         "spatie/laravel-ray": "^1.39.1",
         "spatie/pest-plugin-snapshots": "^2.2.0"
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,13 +5,6 @@
       <directory>tests</directory>
     </testsuite>
   </testsuites>
-  <coverage>
-    <report>
-      <html outputDirectory="build/coverage"/>
-      <text outputFile="build/coverage.txt"/>
-      <clover outputFile="build/logs/clover.xml"/>
-    </report>
-  </coverage>
   <logging>
     <junit outputFile="build/report.junit.xml"/>
   </logging>


### PR DESCRIPTION
## Summary

- Add Laravel 13 support to `illuminate/contracts` and `illuminate/view` constraints.
- Add Testbench 11 support for Laravel 13 compatibility.
- Update Livewire constraint to `^3.5.20|^4.0` for Livewire 4 support.
- Add Laravel 13 to the CI test matrix with PHP 8.2 excluded (Laravel 13 requires PHP 8.3+).