### PR TITLE
Support Livewire v4 by abstracting component class resolution

### DIFF
--- a/config/blade-comments.php
+++ b/config/blade-comments.php
@@ -1,5 +1,16 @@
 <?php
 
+use Spatie\BladeComments\BladeCommentsPrecompiler;
+use Spatie\BladeComments\Commenters\BladeCommenters\BladeComponentCommenter;
+use Spatie\BladeComments\Commenters\BladeCommenters\ExtendsCommenter;
+use Spatie\BladeComments\Commenters\BladeCommenters\IncludeCommenter;
+use Spatie\BladeComments\Commenters\BladeCommenters\LivewireComponentCommenter;
+use Spatie\BladeComments\Commenters\BladeCommenters\LivewireDirectiveCommenter;
+use Spatie\BladeComments\Commenters\BladeCommenters\SectionCommenter;
+use Spatie\BladeComments\Commenters\RequestCommenters\RouteCommenter;
+use Spatie\BladeComments\Commenters\RequestCommenters\ViewCommenter;
+use Spatie\BladeComments\Http\Middleware\AddRequestComments;
+
 return [
     'enable' => env('APP_DEBUG'),
 
@@ -14,20 +25,20 @@ return [
      * various Blade directives.
      */
     'blade_commenters' => [
-        Spatie\BladeComments\Commenters\BladeCommenters\BladeComponentCommenter::class,
-        Spatie\BladeComments\Commenters\BladeCommenters\ExtendsCommenter::class,
-        Spatie\BladeComments\Commenters\BladeCommenters\IncludeCommenter::class,
-        Spatie\BladeComments\Commenters\BladeCommenters\LivewireComponentCommenter::class,
-        Spatie\BladeComments\Commenters\BladeCommenters\LivewireDirectiveCommenter::class,
-        Spatie\BladeComments\Commenters\BladeCommenters\SectionCommenter::class,
+        BladeComponentCommenter::class,
+        ExtendsCommenter::class,
+        IncludeCommenter::class,
+        LivewireComponentCommenter::class,
+        LivewireDirectiveCommenter::class,
+        SectionCommenter::class,
     ],
 
     /*
      * These classes will add comments at the top of the response.
      */
     'request_commenters' => [
-        Spatie\BladeComments\Commenters\RequestCommenters\ViewCommenter::class,
-        Spatie\BladeComments\Commenters\RequestCommenters\RouteCommenter::class,
+        ViewCommenter::class,
+        RouteCommenter::class,
     ],
 
     /*
@@ -35,14 +46,14 @@ return [
      * to the start of a rendered HTML page.
      */
     'middleware' => [
-        Spatie\BladeComments\Http\Middleware\AddRequestComments::class,
+        AddRequestComments::class,
     ],
 
     /*
      * This class is responsible for calling the registered Blade commenters.
      * In most cases, you don't need to modify this class.
      */
-    'precompiler' => Spatie\BladeComments\BladeCommentsPrecompiler::class,
+    'precompiler' => BladeCommentsPrecompiler::class,
 
     'excludes' => [
         /**

--- a/src/Commenters/BladeCommenters/LivewireClassResolver.php
+++ b/src/Commenters/BladeCommenters/LivewireClassResolver.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Spatie\BladeComments\Commenters\BladeCommenters;
+
+use Livewire\Mechanisms\ComponentRegistry;
+
+class LivewireClassResolver
+{
+    public function getClass(string $name): ?string
+    {
+        if (class_exists(ComponentRegistry::class)) {
+            return app(ComponentRegistry::class)->getClass($name);
+        }
+
+        if (app()->bound('livewire.factory')) {
+            return app('livewire.factory')->resolveComponentClass($name);
+        }
+
+        return null;
+    }
+}

--- a/src/Commenters/BladeCommenters/LivewireComponentCommenter.php
+++ b/src/Commenters/BladeCommenters/LivewireComponentCommenter.php
@@ -2,12 +2,13 @@
 
 namespace Spatie\BladeComments\Commenters\BladeCommenters;
 
-use Livewire\Mechanisms\ComponentRegistry;
 use Stillat\BladeParser\Document\Document;
 use Stillat\BladeParser\Nodes\Components\ComponentNode;
 
 class LivewireComponentCommenter
 {
+    public function __construct(protected LivewireClassResolver $resolver) {}
+
     public function parse(string $bladeContent): string
     {
         $document = Document::fromText($bladeContent, null, ['livewire']);
@@ -16,15 +17,12 @@ class LivewireComponentCommenter
             return $bladeContent;
         }
 
-        $registry = app(ComponentRegistry::class);
-
         $document
             ->getComponents()
             ->filter(fn (ComponentNode $node) => $node->componentPrefix == 'livewire')
-            ->transform(function (ComponentNode $node) use ($registry) {
-
+            ->transform(function (ComponentNode $node) {
                 $name = $node->getName();
-                $class = $registry->getClass($name);
+                $class = $this->resolver->getClass($name);
 
                 $start = "<!-- Start Livewire component: '{$class}' '{$name}' -->";
                 $end = "<!-- End Livewire component: '{$class}' '{$name}' -->";

--- a/src/Commenters/BladeCommenters/LivewireDirectiveCommenter.php
+++ b/src/Commenters/BladeCommenters/LivewireDirectiveCommenter.php
@@ -2,13 +2,14 @@
 
 namespace Spatie\BladeComments\Commenters\BladeCommenters;
 
-use Livewire\Mechanisms\ComponentRegistry;
 use Stillat\BladeParser\Document\Document;
 use Stillat\BladeParser\Document\DocumentOptions;
 use Stillat\BladeParser\Nodes\DirectiveNode;
 
 class LivewireDirectiveCommenter
 {
+    public function __construct(protected LivewireClassResolver $resolver) {}
+
     public function parse(string $bladeContent): string
     {
         // Add custom directive
@@ -19,15 +20,11 @@ class LivewireDirectiveCommenter
             return $bladeContent;
         }
 
-        // Get the Livewire component registry to obtain the component class names
-        $registry = app(ComponentRegistry::class);
-
         $document
             ->getDirectives()
-            ->transform(function (DirectiveNode $node) use ($registry) {
-
+            ->transform(function (DirectiveNode $node) {
                 $name = str($node->arguments->getArgValues()->get(0))->trim('\'"')->toString();
-                $class = $registry->getClass($name);
+                $class = $this->resolver->getClass($name);
 
                 $start = "<!-- Start Livewire component: '{$class}' '{$name}' -->";
                 $end = "<!-- End Livewire component: '{$class}' '{$name}' -->";

--- a/tests/Middleware/AddRequestCommentsTest.php
+++ b/tests/Middleware/AddRequestCommentsTest.php
@@ -2,7 +2,9 @@
 
 namespace Tests\Middleware;
 
+use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Route;
+use Spatie\BladeComments\Commenters\RequestCommenters\ViewCommenter;
 use Spatie\BladeComments\Http\Middleware\AddRequestComments;
 
 describe('Comment Generation', function () {
@@ -73,7 +75,7 @@ describe('Error Handling', function () {
      */
     it('gracefully handles responses without valid view objects', function () {
         Route::get('custom-response-route', function () {
-            $response = new \Illuminate\Http\Response('Custom HTML content');
+            $response = new Response('Custom HTML content');
             $response->original = new \stdClass; // Object without name() method
             $response->header('Content-Type', 'text/html');
 
@@ -109,7 +111,7 @@ describe('Comment Configuration', function () {
         config([
             'blade-comments.enable' => true,
             'blade-comments.request_commenters' => [
-                \Spatie\BladeComments\Commenters\RequestCommenters\ViewCommenter::class,
+                ViewCommenter::class,
             ],
         ]);
 


### PR DESCRIPTION
Fixes #53.

`LivewireComponentCommenter` and `LivewireDirectiveCommenter` resolved component classes through `Livewire\Mechanisms\ComponentRegistry`, which was removed in Livewire v4. With Livewire v4 installed, every page render hit `BindingResolutionException: Target class [Livewire\Mechanisms\ComponentRegistry] does not exist.`.

## Changes

- New `LivewireClassResolver` that returns the class for a Livewire component name on both versions:
  - **Livewire v3**: resolves via `Livewire\Mechanisms\ComponentRegistry::getClass()`.
  - **Livewire v4**: resolves via the `livewire.factory` binding (`Livewire\Factory\Factory::resolveComponentClass()`), which is the public replacement for `getClass()`.
- Both commenters now constructor-inject the resolver and delegate the lookup, dropping the direct dependency on the removed class.

## Verified

- Existing test suite (32 tests, 41 assertions) passes against `livewire/livewire ^3.5.20` and `^4.0`.
- The `LivewireTest` snapshot, which exercises both `<livewire:...>` tags and `@livewire(...)` directives, is unchanged.